### PR TITLE
Removed unused variable

### DIFF
--- a/luapgsql.c
+++ b/luapgsql.c
@@ -385,7 +385,7 @@ conn_exec(lua_State *L)
 static int
 get_sql_params(lua_State *L, int t, int n, Oid *paramTypes, char **paramValues)
 {
-	double v, i;
+	double v;
 	int k;
 
 	switch (lua_type(L, t)) {


### PR DESCRIPTION
Fixes

```
luapgsql.c: In function ‘get_sql_params’:
luapgsql.c:388:12: warning: unused variable ‘i’ [-Wunused-variable]
  double v, i;
            ^
```
