### PR TITLE
Prevent segfaults when using :trace()

### DIFF
--- a/luapgsql.c
+++ b/luapgsql.c
@@ -47,6 +47,17 @@
 
 #include "luapgsql.h"
 
+static PGconn **
+pgsql_conn_new(lua_State *L) {
+	PGconn **data;
+
+	data = lua_newuserdata(L, sizeof(PGconn *));
+	*data = NULL;
+	luaL_getmetatable(L, CONN_METATABLE);
+	lua_setmetatable(L, -2);
+	return data;
+}
+
 /*
  * Database Connection Control Functions
  */
@@ -55,12 +66,9 @@ pgsql_connectdb(lua_State *L)
 {
 	PGconn **data;
 
-	data = (PGconn **)lua_newuserdata(L, sizeof(PGconn *));
+	data = pgsql_conn_new(L);
 	*data = PQconnectdb(luaL_checkstring(L, 1));
-	if (*data != NULL) {
-		luaL_getmetatable(L, CONN_METATABLE);
-		lua_setmetatable(L, -2);
-	} else
+	if (*data == NULL)
 		lua_pushnil(L);
 	return 1;
 }
@@ -70,12 +78,9 @@ pgsql_connectStart(lua_State *L)
 {
 	PGconn **data;
 
-	data = (PGconn **)lua_newuserdata(L, sizeof(PGconn *));
+	data = pgsql_conn_new(L);
 	*data = PQconnectStart(luaL_checkstring(L, 1));
-	if (*data != NULL) {
-		luaL_getmetatable(L, CONN_METATABLE);
-		lua_setmetatable(L, -2);
-	} else
+	if (*data == NULL)
 		lua_pushnil(L);
 	return 1;
 }

--- a/luapgsql.c
+++ b/luapgsql.c
@@ -174,6 +174,10 @@ conn_finish(lua_State *L)
 		if (lua_isnil(L, -1)) {
 			PQfinish(*conn);
 			*conn = NULL;
+			/* clean out now invalidated keys from uservalue */
+			lua_getuservalue(L, 1);
+			lua_pushnil(L);
+			lua_setfield(L, -2, "trace_file");
 		} else
 			lua_pop(L, 1);
 	}

--- a/luapgsql.c
+++ b/luapgsql.c
@@ -47,12 +47,20 @@
 
 #include "luapgsql.h"
 
+
+#if LUA_VERSION_NUM < 502
+	#define lua_setuservalue lua_setfenv
+	#define lua_getuservalue lua_getfenv
+#endif
+
 static PGconn **
 pgsql_conn_new(lua_State *L) {
 	PGconn **data;
 
 	data = lua_newuserdata(L, sizeof(PGconn *));
 	*data = NULL;
+	lua_newtable(L);
+	lua_setuservalue(L, -2);
 	luaL_getmetatable(L, CONN_METATABLE);
 	lua_setmetatable(L, -2);
 	return data;


### PR DESCRIPTION
Addresses issues in #23 

  - close functions are wrapped as discussed on IRC and in https://github.com/mbalmer/luapgsql/issues/23#issuecomment-76756882

  - I also attach the file object to the `PGconn` userdata so that it won't get collected if it leaves scope (which allows the nice pattern of `function enableTracing(conn, filename) local f = io.open(filename, 'w') conn:trace(f) end`

The code became a bit bloated due to the different way file handles work in lua 5.1 combined with the coding style.